### PR TITLE
Integrate GPU progress reporting (#16)

### DIFF
--- a/src/gpu/tester.rs
+++ b/src/gpu/tester.rs
@@ -20,13 +20,13 @@ use wgpu::{Adapter, Device, Queue};
 ///
 /// Tests GPU memory using compute shaders that write and verify
 /// test patterns in VRAM.
-#[allow(dead_code)] // Used in Issue #15, integrated in Issue #16
 pub struct GpuTester {
     /// The wgpu device for GPU operations.
     device: Device,
     /// The command queue for submitting work.
     queue: Queue,
     /// Information about the GPU being tested.
+    #[allow(dead_code)] // Used in MemoryTester::device_info()
     gpu_info: GpuInfo,
     /// Shader manager with compute pipelines.
     shaders: ShaderManager,
@@ -34,11 +34,11 @@ pub struct GpuTester {
     buffers: BufferManager,
     /// Timeout for GPU operations.
     timeout: Duration,
-    /// Enable verbose output.
+    /// Enable verbose output (used via config.verbose in run_tests).
+    #[allow(dead_code)]
     verbose: bool,
 }
 
-#[allow(dead_code)] // Used in Issue #15, integrated in Issue #16
 impl GpuTester {
     /// Creates a new GPU tester for the specified adapter.
     ///
@@ -89,11 +89,13 @@ impl GpuTester {
     }
 
     /// Returns information about the GPU being tested.
+    #[allow(dead_code)] // Used in tests
     pub fn gpu_info(&self) -> &GpuInfo {
         &self.gpu_info
     }
 
     /// Returns the amount of memory being tested in bytes.
+    #[allow(dead_code)] // Used in tests
     pub fn buffer_size(&self) -> u64 {
         self.buffers.buffer_size()
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,18 @@ use clap::Parser;
 use cpu::{CpuTester, CpuTesterConfig};
 use stats::TestStats;
 
+#[cfg(feature = "gpu")]
+use std::sync::atomic::Ordering;
+
+#[cfg(feature = "gpu")]
+use gpu::{enumerate_gpus, select_gpu, GpuTester};
+
+#[cfg(feature = "gpu")]
+use indicatif::{ProgressBar, ProgressStyle};
+
+#[cfg(feature = "gpu")]
+use traits::{MemoryTester, TestConfig};
+
 const DEFAULT_TOTAL_MB: usize = 1024; // 1 GB default
 
 #[derive(Parser, Debug)]
@@ -103,6 +115,18 @@ fn main() {
         eprintln!("Warning: --gpu-index has no effect without --gpu flag");
     }
 
+    // Run appropriate tester
+    if args.gpu {
+        #[cfg(feature = "gpu")]
+        {
+            run_gpu_test(&args);
+        }
+    } else {
+        run_cpu_test(&args);
+    }
+}
+
+fn run_cpu_test(args: &Args) {
     // Create CPU tester configuration
     let config = CpuTesterConfig {
         memory_mb: args.memory_mb,
@@ -151,6 +175,151 @@ fn main() {
         println!();
         println!("SUCCESS: No memory errors detected!");
         std::process::exit(0);
+    }
+}
+
+#[cfg(feature = "gpu")]
+fn run_gpu_test(args: &Args) {
+    // Select GPU
+    let adapter = match select_gpu(args.gpu_index) {
+        Ok(adapter) => adapter,
+        Err(e) => {
+            eprintln!("Error selecting GPU: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    // Get GPU info
+    let gpus = enumerate_gpus();
+    let gpu_index = args.gpu_index.unwrap_or(0);
+    let gpu_info = if gpu_index < gpus.len() {
+        gpus[gpu_index].clone()
+    } else {
+        eprintln!("GPU index {} not found", gpu_index);
+        std::process::exit(1);
+    };
+
+    // Create GPU tester
+    let mut tester = match GpuTester::new(
+        adapter,
+        gpu_info.clone(),
+        args.memory_mb,
+        args.gpu_timeout,
+        args.verbose,
+    ) {
+        Ok(tester) => tester,
+        Err(e) => {
+            eprintln!("Error creating GPU tester: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    // Print header
+    println!("GPU Memory Stress Test");
+    println!("======================");
+    println!("GPU: {} ({:?})", gpu_info.name, gpu_info.backend);
+    println!("VRAM to test: {} MB", args.memory_mb);
+    println!(
+        "Mode: {}",
+        if args.continuous {
+            "Continuous"
+        } else {
+            "Single pass"
+        }
+    );
+    if let Some(ref duration_str) = args.duration {
+        println!("Duration: {}", duration_str);
+    }
+    println!();
+
+    // Create test config
+    let config = TestConfig {
+        memory_mb: args.memory_mb,
+        patterns: patterns::TestPattern::all_patterns(),
+        continuous: args.continuous,
+        timeout: args.duration.as_ref().and_then(|s| parse_duration(s)),
+        threads: None,
+        verbose: args.verbose,
+    };
+
+    let stats = Arc::new(TestStats::new());
+    let should_stop = Arc::new(AtomicBool::new(false));
+    let start_time = Instant::now();
+
+    // Create progress bar
+    let pb = ProgressBar::new(config.patterns.len() as u64);
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template("{spinner:.green} [{bar:40.cyan/blue}] {pos}/{len} patterns | {msg}")
+            .unwrap()
+            .progress_chars("=> "),
+    );
+
+    // Start progress update thread
+    let stats_clone = Arc::clone(&stats);
+    let should_stop_clone = Arc::clone(&should_stop);
+    let pb_clone = pb.clone();
+    let progress_handle = std::thread::spawn(move || {
+        while !should_stop_clone.load(Ordering::Relaxed) {
+            let bytes = stats_clone.get_bytes();
+            let errors = stats_clone.get_errors();
+            let elapsed = start_time.elapsed();
+
+            pb_clone.set_message(format!(
+                "{} MB tested | {} errors | {:.1}s",
+                bytes / (1024 * 1024),
+                errors,
+                elapsed.as_secs_f64()
+            ));
+
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    });
+
+    // Run GPU tests
+    let results = tester.run_tests(&config, Arc::clone(&stats), Arc::clone(&should_stop));
+
+    // Signal progress thread to stop
+    should_stop.store(true, Ordering::Relaxed);
+    progress_handle.join().expect("Progress thread panicked");
+
+    // Update progress bar with final count
+    pb.set_position(config.patterns.len() as u64);
+    pb.finish_with_message("Complete");
+
+    // Print results
+    let total_errors: u64 = match &results {
+        Ok(r) => r.iter().map(|r| r.errors_found).sum(),
+        Err(_) => 0,
+    };
+
+    println!();
+    println!("Test Complete");
+    println!("=============");
+    println!(
+        "Total bytes tested: {} MB",
+        stats.get_bytes() / (1024 * 1024)
+    );
+    println!("Total tests completed: {}", stats.get_tests());
+    println!("Errors found: {}", total_errors);
+    println!("Duration: {:.2}s", start_time.elapsed().as_secs_f64());
+
+    match results {
+        Ok(_) if total_errors == 0 => {
+            println!();
+            println!("SUCCESS: No GPU memory errors detected!");
+            std::process::exit(0);
+        }
+        Ok(_) => {
+            println!();
+            println!("GPU MEMORY ERRORS DETECTED!");
+            std::process::exit(1);
+        }
+        Err(e) => {
+            eprintln!();
+            eprintln!("GPU test error: {}", e);
+            std::process::exit(1);
+        }
     }
 }
 

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -56,7 +56,7 @@ impl TestPattern {
     /// Returns the numeric pattern ID for GPU shaders.
     ///
     /// These IDs must match the constants in the WGSL shader files.
-    #[allow(dead_code)] // Used in Issue #14, integrated in Issue #16
+    #[cfg(feature = "gpu")]
     pub fn pattern_id(&self) -> u32 {
         match self {
             Self::WalkingOnes => 0,


### PR DESCRIPTION
## Summary
- Integrates GPU testing into main.rs with `--gpu` flag support
- Adds real-time progress bar showing pattern count, bytes tested, and errors
- Progress updates at 10 Hz via background thread
- Displays clean summary on completion matching CPU output style

## Changes
- `main.rs`: Add `run_gpu_test()` function with indicatif progress bar
- `main.rs`: Split CPU path into `run_cpu_test()` function for clarity
- `patterns.rs`: Make `pattern_id()` GPU-only via `#[cfg(feature = "gpu")]`
- `tester.rs`: Clean up dead_code annotations

## Test plan
- [x] All 81 tests pass with `cargo test --all-features`
- [x] Clippy passes with `cargo clippy --all-features -- -D warnings`
- [x] Non-GPU build still compiles and runs correctly
- [ ] Manual test: `ferritest --gpu` shows progress bar
- [ ] Manual test: `ferritest --list-gpus` lists available GPUs
- [ ] Manual test: `ferritest --gpu --gpu-index 0` selects specific GPU

Closes #16

Generated with [Claude Code](https://claude.com/claude-code)