### PR TITLE
Bonus: Add graceful Ctrl+C shutdown handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ num_cpus = "1.16"
 humantime = "2.1"
 bytesize = "1.3"
 thiserror = "2.0.17"
+ctrlc = "3.4"
 
 # GPU support (feature-gated)
 wgpu = { version = "27.0", optional = true }


### PR DESCRIPTION
## Summary
- Adds cross-platform Ctrl+C signal handling using the `ctrlc` crate
- Tests stop gracefully when interrupted, finishing the current operation
- Shows "Test Interrupted" message instead of abrupt termination
- Multi-GPU mode skips remaining GPUs after interrupt

## Changes
- Added `ctrlc = "3.4"` dependency
- Set up signal handler in `main()` that sets shared `should_stop` flag  
- Pass `should_stop` through to CPU, GPU, and multi-GPU test functions
- Updated result display to show interrupted status

## Test plan
- [x] `cargo test --all-features` passes (86 tests)
- [x] `cargo build --no-default-features` compiles
- [x] `cargo clippy --all-features` clean
- [ ] Manual test: run `ferritest` and press Ctrl+C to verify graceful shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)